### PR TITLE
Include license information in gemspec

### DIFF
--- a/pingback.gemspec
+++ b/pingback.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/AndreasWurm/pingback"
   s.summary     = "This library enables the user to write pingback aware applications."
   s.description = "This library enables the user to write pingback aware applications."
+  s.license     = "GPL-3"
 
   s.required_rubygems_version = ">= 1.3.6"
 


### PR DESCRIPTION
RubyGems.org doesn't report a license for your gem. This is because it is not specified in the [gemspec](http://guides.rubygems.org/specification-reference/#license=) of your last release.

Including a license in your gemspec is an easy way for rubygems.org and other tools to check how your gem is licensed. As you can imagine, scanning your repository for a LICENSE file or parsing the README, and then attempting to identify the license or licenses is much more difficult and more error prone. So, even for projects that already specify a license, including a license in your gemspec is a good practice. See, for example, [how rubygems.org uses the gemspec to display the rails gem license](https://rubygems.org/gems/rails).

There is even a [License Finder gem](https://github.com/pivotal/LicenseFinder) to help companies/individuals ensure all gems they use meet their licensing needs. This tool depends on license information being available in the gemspec. This is an important enough issue that even Bundler now generates gems with a default 'MIT' license.

I hope you'll consider specifying a license in your gemspec. If not, please just close the issue with a nice message. In either case, I'll follow up. Thanks for your time!

_Message cribbed from Benjamin Fleischer's typical "add license" verbiage_
