### PR TITLE
Adding the dependency

### DIFF
--- a/pingback.gemspec
+++ b/pingback.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'nokogiri'
   s.add_dependency 'rack'
-
+  s.add_dependency 'xmlrpc'
+  
   s.add_development_dependency "rake", "10.4.2"
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rspec", ">= 2.5.0"


### PR DESCRIPTION
I am [adding Pingback support for my Jekyll Webmentions plugin](https://github.com/aarongustafson/jekyll-webmention_io/issues/11) and it’s failing because the XMLRPC dependency is not included.